### PR TITLE
Style: Hide scrollbar in stacked tabs

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -357,3 +357,8 @@ iframe[src*="youtu"] {
     border-radius: 10px;
 }
 
+/* Stacked Tabsのスクロールバーを非表示に*/
+.workspace-tabs.mod-stacked ::-webkit-scrollbar {
+  display: none;
+}
+


### PR DESCRIPTION
カスタム背景を有効化した際，Stacked Tabs下部のスクロールバーにテーマが適用されない表示上の問題をWindows環境で確認しました．
そこで，テーマの外観を加味してStacked Tabsのスクロールバーを非表示にするcssの修正を提案します．